### PR TITLE
Update `equipedLoot` upon equip

### DIFF
--- a/frontend/src/components/Actions/Equipment.tsx
+++ b/frontend/src/components/Actions/Equipment.tsx
@@ -1,16 +1,18 @@
 // *EXTERNALS*
 import React, { useEffect, useState } from 'react';
 import { TransactionStatus } from '@usedapp/core';
+import { STAKE_CONTRACT_ADDRESS } from 'dungeon-defenders-contracts';
 
 // *INTERNALS*
 import { useEquip, useUnequip, useSlots, useApproveLoot, useAllowanceLoot } from '../../hooks/index';
-import { STATUS_TYPES, STAKE_CONTRACT_ADDRESS } from '../../constants';
+import { STATUS_TYPES } from '../../constants';
 import LoadingBtn from '../LoadingBtn';
 import { sendTx, handleTxStatus } from '../../utils';
 
 type ActionProps = {
   tokenId: number | string;
   userAddress: string;
+  onEquipmentUpdated?: (slots: number[]) => void
 };
 
 type FormProps = {
@@ -66,7 +68,7 @@ const FormUtil = ({ label, value, onChange, disabled, children }: FormProps) => 
   );
 };
 
-const Equipment: React.FC<ActionProps> = ({ userAddress, tokenId }) => {
+const Equipment: React.FC<ActionProps> = ({ userAddress, tokenId, onEquipmentUpdated }) => {
   // *HOOKS*
   const { state: equipState, send: sendEquip } = useEquip();
   const { state: unequipState, send: sendUnequip } = useUnequip();
@@ -96,6 +98,12 @@ const Equipment: React.FC<ActionProps> = ({ userAddress, tokenId }) => {
   useEffect(() => {
     handleTxStatus(STATES, STATUS, handleStateChange);
   }, [STATES]);
+
+  useEffect(() => {
+    if (onEquipmentUpdated) {
+      onEquipmentUpdated(loots);
+    }
+  }, [loots])
 
   const handleSetLoot = (value: React.ChangeEvent<HTMLInputElement>, index: number) => {
     const newLoot = JSON.parse(JSON.stringify(loots));

--- a/frontend/src/components/Actions/Faucet.tsx
+++ b/frontend/src/components/Actions/Faucet.tsx
@@ -2,8 +2,10 @@
 import { ethers } from 'ethers';
 import { TransactionStatus } from '@usedapp/core';
 import React, { useEffect, useState } from 'react';
+import { FAUCET_CONTRACT_ADDRESS } from 'dungeon-defenders-contracts';
+
 // *INTERNALS*
-import { STATUS_TYPES, FAUCET_CONTRACT_ADDRESS, GEMS_TOTAL_SUPPLY } from '../../constants';
+import { STATUS_TYPES, GEMS_TOTAL_SUPPLY } from '../../constants';
 import {
   useDeposit,
   useClaim,

--- a/frontend/src/components/Actions/Play.tsx
+++ b/frontend/src/components/Actions/Play.tsx
@@ -3,6 +3,7 @@ import { ethers } from 'ethers';
 import React, { useEffect, useState } from 'react';
 import { TransactionStatus } from '@usedapp/core';
 import { useNavigate } from 'react-router-dom';
+import { STAKE_CONTRACT_ADDRESS } from 'dungeon-defenders-contracts';
 
 // *INTERNALS*
 import {
@@ -15,7 +16,7 @@ import {
   useApproveGEMS,
   useStakes,
 } from '../../hooks/index';
-import { STAKE_CONTRACT_ADDRESS, STATUS_TYPES, GEMS_TOTAL_SUPPLY } from '../../constants';
+import { STATUS_TYPES, GEMS_TOTAL_SUPPLY } from '../../constants';
 import LoadingBtn from '../LoadingBtn';
 import { sendTx, handleTxStatus } from '../../utils';
 
@@ -98,7 +99,7 @@ const Play: React.FC<ActionProps> = ({ userAddress, tokenId, equipedLoot }) => {
       if (index === 2) {
         setTimeout(async () => {
           navigate(`/Play`, {
-            replace: true,
+            replace: false,
             state: {
               owner: userAddress,
               defenderId: tokenId,

--- a/frontend/src/components/NFTCard.tsx
+++ b/frontend/src/components/NFTCard.tsx
@@ -1,5 +1,5 @@
 // *EXTERNALS*
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useEthers } from '@usedapp/core';
 
@@ -24,10 +24,19 @@ const NFTCard = ({ NFT, owner, isLoot }: Props) => {
   const { account } = useEthers();
   const stakes = account && useStakes(account);
   const slots = !isLoot && useSlots(tokenId);
+  const [equipedLoot, setEquipedLoot] = useState(slots ? [slots[1], slots[2], slots[3]] : [0, 0, 0]);
   const userStaking = stakes && +stakes.timestamp > 0;
   const stakedId = stakes && +stakes.tokenId;
   const isOwner = account === owner;
   const isUserStakedToken = userStaking && actualTokenId == stakedId;
+
+  useEffect(() => {
+    if (slots && slots !== equipedLoot) setEquipedLoot(slots);
+  }, [slots.toString()]);
+
+  const onEquipmentUpdated = (updatedSlots: number[]) => {
+    setEquipedLoot(updatedSlots);
+  }
 
   const getMetadataDisplay = () => {
     return (
@@ -51,7 +60,7 @@ const NFTCard = ({ NFT, owner, isLoot }: Props) => {
         <div>
           {account && !isLoot && slots && (isOwner || isUserStakedToken) && (
             <>
-              <Equipment userAddress={account} tokenId={actualTokenId} />
+              <Equipment userAddress={account} tokenId={actualTokenId} onEquipmentUpdated={onEquipmentUpdated}  />
               <div className="mb-3" />
               <Play userAddress={account} tokenId={actualTokenId} equipedLoot={slots} />
             </>

--- a/frontend/src/game/GameScene.ts
+++ b/frontend/src/game/GameScene.ts
@@ -1,4 +1,4 @@
-import { HALF_UNIT_SIZE, UNIT_SCALE, UNIT_SIZE } from './Constants';
+import { HALF_UNIT_SIZE, UNIT_SIZE } from './Constants';
 import { API_ADDRESS } from '../constants';
 import { Player } from './Player';
 

--- a/frontend/src/game/Player.ts
+++ b/frontend/src/game/Player.ts
@@ -26,6 +26,7 @@ export class Weapon {
 
     create(scene : Phaser.Scene, weaponType: number, layer: Phaser.GameObjects.Layer) {
         this.asset = WEAPONS[weaponType];
+        console.log(weaponType, this.asset)
         this.sprite = scene.add.image(320, 320, this.asset.key);
         this.sprite.setOrigin((this.asset.center.x - 4) / this.asset.frameSize.x, this.asset.center.y / this.asset.frameSize.y);
         this.sprite.scale = UNIT_SCALE;

--- a/frontend/src/game/SimpleDungeonGenerationScene.ts
+++ b/frontend/src/game/SimpleDungeonGenerationScene.ts
@@ -1,4 +1,4 @@
-import { HALF_UNIT_SIZE, UNIT_SCALE, UNIT_SIZE } from "./Constants";
+import { UNIT_SIZE } from "./Constants";
 import { Player } from "./Player";
 
 import { RoomType, simpleDungeonGenerator } from "./SimpleDungeonGenerator";

--- a/frontend/src/routes/Play.tsx
+++ b/frontend/src/routes/Play.tsx
@@ -28,26 +28,24 @@ export default function Play() {
     }
 
     console.log(defender, weapon);
-    if (!defender) {
+    if (!defender || (state.weaponId && !weapon)) {
       return;
     }
 
-    const w: Loot = {
-      health: 0,
-      speed: 0,
-      strength: 0,
-      defense: 0,
-
-      // Aesthetics
-      background: 0,
-      weapon: 4,
-      armor: 0,
-      boots: 0,
-    };
-
     setInit(true);
-    initializeGame('game', { ownerAddress: state.owner, defenderId: state.defenderId, defender, weapon: w });
   }, [defender, weapon]);
+
+  useEffect(() => {
+    if (!init) {
+      return;
+    }
+
+    if (!defender || (state.weaponId && !weapon)) {
+      return;
+    }
+
+    initializeGame('game', { ownerAddress: state.owner, defenderId: state.defenderId, defender, weapon });
+  }, [init])
 
   return (
     <>


### PR DESCRIPTION
Before this fix the in game character would only equip the loot that was on the nft when the nft was loaded into the frontend.

After this fix the in game character will equip the loot you equip while on the nft page without refresh.

The issue was the `Equipment` component was not sharing state with the `NFTCard` component.
Alternatively I considered getting the equipment for a defender on play but querying the blockchain just adds delay for the user.